### PR TITLE
PDFGenerator.java: fix #13

### DIFF
--- a/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
+++ b/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
@@ -123,9 +123,18 @@ public class PDFGenerator {
                     pageHeight - bufferTop);
             // we have a map of measure number to count per measure
             // currently assumes 4 counts per measure
-            // TODO: Make measures adjust with changes in count per measure
             begMeasure = endMeasure;
-            endMeasure = begMeasure + move.getCounts() / 4;
+            int totalCounts = 0;
+            int currentMeasure = begMeasure;
+            while (move.getCounts() > totalCounts){
+                try {
+                    totalCounts += drillInfo.getCountsHashMap().get(currentMeasure);
+                } catch (NullPointerException e) {
+                    totalCounts += 4;
+                }
+                currentMeasure ++;
+            }
+            endMeasure = currentMeasure;
             if (begMeasure != endMeasure) {
                 contentStream.showText("Measures:  " + (begMeasure + 1)
                         + " - " + endMeasure);


### PR DESCRIPTION
Fix the issue by using DrillInfo.getCountsHashMap() to calculate the correct measure numbers. Still assumes a default of 4 counts per measure.